### PR TITLE
Composite name within tooltip

### DIFF
--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -36,10 +36,20 @@ export class Tooltip {
           </tr>
         `;
       }
+      const compositeContent =
+        data[index].displayMode === 'all'
+          ? ''
+          : `
+        <tr>
+          <th colspan="2" style="text-align: center;">${data[index].name}</th>
+        </tr>
+      `;
+
       const content = [
         `
         <table width="100%" class="polystat-panel-tooltiptable">
         <thead>
+          ${compositeContent}
           <tr>
             <th style="text-align: left;">Name</th>
             <th style="text-align: right;">Value</th>

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -29,7 +29,6 @@ export class Tooltip {
           continue;
         }
       }
-      const content = [];
       if (polystat.tooltipTimestampEnabled) {
         timestampContent = `
           <tr>
@@ -37,7 +36,8 @@ export class Tooltip {
           </tr>
         `;
       }
-      content.push(`
+      const content = [
+        `
         <table width="100%" class="polystat-panel-tooltiptable">
         <thead>
           <tr>
@@ -49,7 +49,8 @@ export class Tooltip {
           ${timestampContent}
         </tfoot>
         <tbody>
-      `);
+      `,
+      ];
 
       /* Scenarios:
         tooltip set to trigggered

--- a/src/transformers.test.ts
+++ b/src/transformers.test.ts
@@ -56,7 +56,7 @@ describe('Transforms', () => {
 
   // Datasource sends ElasticSearch results
   describe('With elasticsearch data', () => {
-    it('Can convert to hexbin', () => {
+    it.skip('Can convert to hexbin', () => {
       expect(true).toBeTruthy();
     });
   });
@@ -84,7 +84,7 @@ describe('Transforms', () => {
         type: 'table',
       },
     ];
-    it('Converts Table Data', () => {
+    it.skip('Converts Table Data', () => {
       console.log(tableData);
     });
     /*
@@ -121,7 +121,7 @@ describe('Transforms', () => {
 
   // Datasource sends JSON
   describe('With JSON data', () => {
-    it('Can convert to hexbin', () => {
+    it.skip('Can convert to hexbin', () => {
       const rawData = [
         {
           type: 'docs',


### PR DESCRIPTION
Fixes #52 

See commit messages for the breakdown.

---

![composite](https://user-images.githubusercontent.com/170197/73683454-411ee480-4690-11ea-8be4-68505f4621c7.png)

When not a composite, there is no tooltip title:
![all](https://user-images.githubusercontent.com/170197/73683463-4419d500-4690-11ea-9d2e-8b6db408d9fc.png)
