### PR TITLE
set dependency

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -45,8 +45,8 @@
     },
 
     "dependencies": {
-        "grafanaVersion": "7.x.x",
-        "grafanaDependency": ">=7.0.0",
+        "grafanaVersion": "6.5.3",
+        "grafanaDependency": ">=6.5.3",
         "plugins": []
     }
 }


### PR DESCRIPTION
master (and 1.2.x) are compatible with 6.5.3 forward