### PR TITLE
fix for null data and zero values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Entries
 
+## v1.2.5
+
+- Fix for null data from a query stopping processing other queries
+
 ## v1.2.4
 
 - Convert to use dataframes

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Then browse to <http://localhost:3000>
 
 ## External Dependencies
 
-* Grafana 6.5.3+
+* Grafana 7.3+
 
 ## Enable Grafana TestData
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-polystat-panel",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Grafana Polystat Panel",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/core/data_processor.ts
+++ b/src/core/data_processor.ts
@@ -51,7 +51,7 @@ export class DataProcessor {
           const fieldValues = field.values.get(r);
           const timeValues = timeField.values.get(r);
           // make sure there are values, this can end up being undefined
-          if (fieldValues) {
+          if (typeof fieldValues !== undefined) {
             datapoints.push([fieldValues, timeValues]);
           }
         }


### PR DESCRIPTION
- When multiple queries are used and one returned null results, the data processor would error and not display any results
- Same code block would also interpret "0" as invalid data
- bump version to 1.2.5