### PR TITLE
fix for composite template variables

### DIFF
--- a/.config/webpack/utils.ts
+++ b/.config/webpack/utils.ts
@@ -33,8 +33,9 @@ export async function getEntries(): Promise<Record<string, string>> {
     return modules.reduce((result, module) => {
       const pluginPath = path.resolve(path.dirname(module), parent);
       const pluginName = path.basename(pluginPath);
+      const entryName = plugins.length > 1 ? `${pluginName}/module` : 'module';
   
-      result[`${pluginName}/module`] = path.join(parent, module);
+      result[entryName] = path.join(parent, module);
       return result;
     }, result);
   }, {});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Entries
 
+## v2.0.1
+
+- Fixes ability to use template variables inside composite names
+- Fixes hide/show composite member metrics when they overlap in multiple composites
+
 ## v2.0.0
 
 - Plugin has been converted to React

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-polystat-panel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Grafana Polystat Panel",
   "scripts": {
     "build": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/data/composite_processor.ts
+++ b/src/data/composite_processor.ts
@@ -13,7 +13,7 @@ const resolveCompositeTemplates = (
 ): CompositeItemType[] => {
   const ret: CompositeItemType[] = [];
   metricComposites.forEach((item: CompositeItemType) => {
-    const resolved = replaceVariables(item.name, undefined, customFormatter).split('#️⃣🔠🆗🆗🔠#️⃣');
+    const resolved = replaceVariables(item.name, undefined, customFormatter).split(CUSTOM_SPLIT_DELIMITER);
     // if the composite name has template syntax, mark it as isTemplated true
     const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::(\w+))?}/g;
     const matchResult = item.name.match(variableRegex);

--- a/src/data/composite_processor.ts
+++ b/src/data/composite_processor.ts
@@ -13,13 +13,18 @@ const resolveCompositeTemplates = (
 ): CompositeItemType[] => {
   const ret: CompositeItemType[] = [];
   metricComposites.forEach((item: CompositeItemType) => {
-    const firstResolve = replaceVariables(item.name); // th e ScopedVars should expand here
-    const resolved = replaceVariables(firstResolve, {}, customFormatter).split(CUSTOM_SPLIT_DELIMITER);
+    const resolved = replaceVariables(item.name, undefined, customFormatter).split('#️⃣🔠🆗🆗🔠#️⃣');
+    // if the composite name has template syntax, mark it as isTemplated true
+    const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::(\w+))?}/g;
+    const matchResult = item.name.match(variableRegex);
+    if (matchResult && matchResult.length > 0) {
+      item.isTemplated = true;
+    }
     resolved.forEach((newName: string) => {
       ret.push({
         ...item,
         name: newName,
-        isTemplated: true,
+        isTemplated: item.isTemplated,
         templatedName: item.name,
       });
     });
@@ -49,23 +54,29 @@ const resolveMemberTemplates = (
     if (member.seriesMatch) {
       const matchResult = member.seriesMatch.match(variableRegex);
       if (matchResult && matchResult.length > 0) {
-        matchResult.forEach((template) => {
+        matchResult.forEach((aMatch) => {
           // if the template contains the composite template, replace it with the compositeName
-          if (isTemplated && template.includes(templatedName)) {
+          if (isTemplated && aMatch.includes(templatedName)) {
             // replace it
-            template = template.replace(templatedName, compositeName);
-          }
-          const resolvedSeriesNames = [replaceVariables(template, {}, 'raw')];
-          resolvedSeriesNames.forEach((seriesName) => {
-            const newName = member.seriesMatch.replace(template, seriesName);
-            const escapedName = escapeStringForRegex(seriesName);
-            const newSeriesNameEscaped = member.seriesMatch.replace(template, escapedName);
+            const compositeExpanded = member.seriesMatch.replace(templatedName, compositeName);
             ret.push({
               ...member,
-              seriesName: newName,
-              seriesNameEscaped: newSeriesNameEscaped,
+              seriesName: compositeExpanded,
+              seriesNameEscaped: compositeExpanded,
             });
-          });
+          } else {
+            const resolvedSeriesNames = [replaceVariables(aMatch, undefined, 'raw')];
+            resolvedSeriesNames.forEach((seriesName) => {
+              const newName = member.seriesMatch.replace(aMatch, seriesName);
+              const escapedName = escapeStringForRegex(seriesName);
+              const newSeriesNameEscaped = member.seriesMatch.replace(aMatch, escapedName);
+              ret.push({
+                ...member,
+                seriesName: newName,
+                seriesNameEscaped: newSeriesNameEscaped,
+              });
+            });
+          }
         });
       } else {
         ret.push(member);
@@ -126,6 +137,7 @@ export const ApplyComposites = (
     return data;
   }
   const filteredMetrics: number[] = [];
+  const keepMetrics: number[] = [];
   const clonedComposites: PolystatModel[] = [];
   // the composite Name can be a template variable
   // the composite should only match specific metrics or expanded templated metrics that use the composite name
@@ -173,6 +185,8 @@ export const ApplyComposites = (
           // only hide if requested
           if (!aComposite.showMembers) {
             filteredMetrics.push(index);
+          } else {
+            keepMetrics.push(index);
           }
           if (aComposite.clickThrough && aComposite.clickThrough.length > 0) {
             // process template variables
@@ -231,6 +245,15 @@ export const ApplyComposites = (
   }
   // now merge the clonedComposites into data
   Array.prototype.push.apply(data, clonedComposites);
+  // remove the keepMetrics from the filteredMetrics list
+  // these have been marked by at least one composite to be displayed
+  for (let i = 0; i < keepMetrics.length; i++) {
+    const keptMetric = keepMetrics[i];
+    const location = filteredMetrics.indexOf(keptMetric);
+    if (location >= 0) {
+      filteredMetrics.splice(location, 1);
+    }
+  }
   // sort by value descending
   filteredMetrics.sort((a, b) => {
     return b - a;

--- a/src/data/composite_processor.ts
+++ b/src/data/composite_processor.ts
@@ -59,21 +59,22 @@ const resolveMemberTemplates = (
           if (isTemplated && aMatch.includes(templatedName)) {
             // replace it
             const compositeExpanded = member.seriesMatch.replace(templatedName, compositeName);
+            const compositeExpandedEscaped = escapeStringForRegex(compositeExpanded);
             ret.push({
               ...member,
               seriesName: compositeExpanded,
-              seriesNameEscaped: compositeExpanded,
+              seriesNameEscaped: compositeExpandedEscaped,
             });
           } else {
             const resolvedSeriesNames = [replaceVariables(aMatch, undefined, 'raw')];
             resolvedSeriesNames.forEach((seriesName) => {
               const newName = member.seriesMatch.replace(aMatch, seriesName);
               const escapedName = escapeStringForRegex(seriesName);
-              const newSeriesNameEscaped = member.seriesMatch.replace(aMatch, escapedName);
+              const newNameEscaped = member.seriesMatch.replace(aMatch, escapedName);
               ret.push({
                 ...member,
                 seriesName: newName,
-                seriesNameEscaped: newSeriesNameEscaped,
+                seriesNameEscaped: newNameEscaped,
               });
             });
           }


### PR DESCRIPTION
fixes #128 

* Composites will now correctly interpret multi-select and "all" for template variables inside the composite name.
* When a composite has "show members" enabled, the metrics will be displayed even when hidden by another composite.

