### PR TITLE
Bugfix: Metric Hints should also include displayNameFromDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Entries
 
+## v2.0.8
+
+- Adds support for additional metric hints depending on the structure of the frames received.
+
 ## v2.0.7
 
 - Fixes metric hint errors when using overrides and composites

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@babel/helper-validator-option": "7.18.6",
-    "@grafana/e2e": "9.4.3",
-    "@grafana/e2e-selectors": "9.4.3",
+    "@grafana/e2e": "9.4.10",
+    "@grafana/e2e-selectors": "9.4.10",
     "@grafana/eslint-config": "^5.1.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@swc/core": "^1.2.144",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-polystat-panel",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Grafana Polystat Panel",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/composites/CompositeMetricItem.test.tsx
+++ b/src/components/composites/CompositeMetricItem.test.tsx
@@ -7,6 +7,7 @@ import { FieldType, toDataFrame } from '@grafana/data';
 
 describe('Test CompositeMetricItem', () => {
   const time = new Date().getTime();
+
   const frameA = toDataFrame({
     fields: [
       { name: 'time', type: FieldType.time, values: [time, time + 1, time + 2] },
@@ -25,14 +26,14 @@ describe('Test CompositeMetricItem', () => {
     removeMetric: undefined,
     updateMetric: undefined,
     updateMetricAlias: undefined,
-    context: { data : [frameA] },
+    context: { data: [frameA] },
   };
   beforeEach(() => { });
 
   describe('Metric Hints', () => {
     it('returns set of hint from labels', () => {
       const { container } = render(
-          <CompositeMetricItem {...props} />
+        <CompositeMetricItem {...props} />
       );
       console.log(container.innerHTML);
       expect(container.innerHTML).toMatchSnapshot();

--- a/src/components/metric_hints.ts
+++ b/src/components/metric_hints.ts
@@ -4,10 +4,23 @@ import { FieldType } from '@grafana/data';
 export const getMetricHints = (frames: any) => {
   let metricHints = new Set<string>();
   for (let i = 0; i < frames.length; i++) {
+    let hintValue;
+    // the frame may have a name defined, start with it, fields will change it as needed
+    if (frames[i]?.name) {
+      hintValue = frames[i].name;
+    }
     // iterate over fields, get all number types and provide as hints
     for (const aField of frames[i].fields) {
       if (aField.type === FieldType.number) {
-        let hintValue = aField.name;
+        // update the hint to use the field Name
+        if (aField.name) {
+          hintValue = aField.name;
+        }
+        // update the hint to use the displayNameFromDS value
+        if (aField?.config && aField.config?.displayNameFromDS) {
+          hintValue = aField.config?.displayNameFromDS;
+        }
+        // lastly check for a label with __name__ and use it instead
         if (aField?.labels && ('__name__' in aField.labels)) {
           hintValue = aField.labels['__name__'];
         }

--- a/src/data/clickThroughTransformer.test.ts
+++ b/src/data/clickThroughTransformer.test.ts
@@ -8,9 +8,9 @@ import { PolystatModel } from '../components/types';
 import { DataFrameToPolystat } from './processor';
 
 describe('ClickThroughTransformer', () => {
-  var modelA: PolystatModel;
-  var modelB: PolystatModel;
-  var models: PolystatModel[] = [];
+  let modelA: PolystatModel;
+  let modelB: PolystatModel;
+  let models: PolystatModel[] = [];
   const field: FieldConfig = {
     decimals: 2,
     unit: 'MBs',

--- a/src/data/composite_processor.test.ts
+++ b/src/data/composite_processor.test.ts
@@ -32,10 +32,10 @@ jest.mock('@grafana/runtime', () => {
 });
 
 describe('Composite Processor', () => {
-  var modelA: PolystatModel;
-  var modelB: PolystatModel;
-  var compositeA: CompositeItemType;
-  var templatedComposite: CompositeItemType;
+  let modelA: PolystatModel;
+  let modelB: PolystatModel;
+  let compositeA: CompositeItemType;
+  let templatedComposite: CompositeItemType;
 
   beforeEach(() => {
     const time = new Date().getTime();

--- a/src/data/threshold_processor.test.ts
+++ b/src/data/threshold_processor.test.ts
@@ -11,11 +11,11 @@ import {
 import { OverrideItemType } from '../components/overrides/types';
 import { PolystatThreshold } from '../components/thresholds/types';
 describe('Threshold Processor', () => {
-  var modelA: PolystatModel;
-  var modelB: PolystatModel;
-  var thresholds: PolystatThreshold[];
+  let modelA: PolystatModel;
+  let modelB: PolystatModel;
+  let thresholds: PolystatThreshold[];
   //@ts-ignore
-  var overrideA: OverrideItemType;
+  let overrideA: OverrideItemType;
   beforeEach(() => {
     const time = new Date().getTime();
     const frameA = toDataFrame({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,24 +1301,24 @@
     tslib "2.3.1"
     typescript "4.4.4"
 
-"@grafana/e2e-selectors@9.4.3":
-  version "9.4.3"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-9.4.3.tgz#55061983ba397e93502c20e550296e696e1f708a"
-  integrity sha512-AaaE+WX2cB2Ik2JExXoeCZtEOutB3hYSLiakZWgymEuntnJ+AAfizLbSZBn8tmZO2IlvF7lgUR48eM4BVfB8Aw==
+"@grafana/e2e-selectors@9.4.10":
+  version "9.4.10"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-9.4.10.tgz#c8cfac2c9679d4a34ab317a9bdacb029d8ae8c91"
+  integrity sha512-4ykTa4FaMWEdPQeoq2pQ44HgffO/1Nh1ibgwbT3P5bDRwAPzGtNfsij5kzo6pnc1oPnOkwaMUOWcvt+sUadENA==
   dependencies:
     "@grafana/tsconfig" "^1.2.0-rc1"
     tslib "2.4.1"
     typescript "4.8.4"
 
-"@grafana/e2e@9.4.3":
-  version "9.4.3"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e/-/e2e-9.4.3.tgz#e9c4f7cfade2820c977db22c0520da1794e3ba0c"
-  integrity sha512-7h5x9+HM62xuaLaGFIOtGLeHD9IUb0WOUvg+YEhHucmDvDfXepuAsSmDW8XGI1DrODZphXKl8LotDg+WFh3ORQ==
+"@grafana/e2e@9.4.10":
+  version "9.4.10"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e/-/e2e-9.4.10.tgz#6c0fa7ff12f0a0f042ff9b1e5f3d227b57a39b78"
+  integrity sha512-OF4SWuh8YantUiylFdD25L7cNMazAc0yLh9ORA/sDQbL9oT/DVepK+61qKYC8u49xv39drXGwxsFWSXWEHvOzw==
   dependencies:
     "@babel/core" "7.20.5"
     "@babel/preset-env" "7.20.2"
     "@cypress/webpack-preprocessor" "5.16.0"
-    "@grafana/e2e-selectors" "9.4.3"
+    "@grafana/e2e-selectors" "9.4.10"
     "@grafana/tsconfig" "^1.2.0-rc1"
     "@mochajs/json-file-reporter" "^1.2.0"
     babel-loader "9.1.0"


### PR DESCRIPTION
This modifies the metric hint behavior to also get names from the frame config.

A DataFrame can have:
* a global name (rarely used)
* a per-frame name
* a config with displayNameFromDS
* labels that specify a name

Added tests to cover this type of data.

Fixes #262 
