### PR TITLE
Enhance metric hints for composites and overrides, fix templated composites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Entries
 
+## v2.0.9
+
+- Fixes multi-select templated composite bug
+- Enhances metric hints for composites and overrides to cover more dataframe options
+
 ## v2.0.8
 
 - Adds support for additional metric hints depending on the structure of the frames received.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-polystat-panel",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Grafana Polystat Panel",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/metric_hints.test.ts
+++ b/src/components/metric_hints.test.ts
@@ -5,6 +5,7 @@ describe('Test Metric Hints', () => {
   let wideFrame: DataFrame;
   let narrowFrame: DataFrame;
   let frameCW: DataFrame;
+  let frameInfluxDB: DataFrame;
   let time: number;
 
   beforeEach(() => {
@@ -54,31 +55,58 @@ describe('Test Metric Hints', () => {
       ],
     });
 
+    frameInfluxDB = toDataFrame({
+      name: 'changePctDay.mean { coin: btc currency: usd }',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [time, time + 1, time + 2] },
+        {
+          name: 'value',
+          type: 'number',
+          typeInfo: { frame: 'float64', nullable: true },
+          labels: {
+            "coin": "btc",
+            "currency": "usd"
+          },
+          config: {
+            displayNameFromDS: 'changePctDay.mean { coin: btc currency: usd }',
+            links: [],
+          },
+          values: [1.1, 2.2, 3.3],
+        },
+      ],
+    });
+
   });
 
 
   describe('Metric Hints', () => {
-    it('returns set of hint from labels', () => {
+    it('returns set of hints from labels', () => {
       const hints = getMetricHints([wideFrame, narrowFrame]);
       expect(hints.size).toEqual(3);
       let val = [...hints][0];
       expect(val).toEqual('A-series');
       val = [...hints][1];
-      expect(val).toEqual('B with Label');
+      expect(val).toEqual('B with Label{fake-label-b="BName"}');
       val = [...hints][2];
       expect(val).toEqual('C-series');
     });
-    it('returns hints no labels', () => {
+    it('returns hints with no labels', () => {
       const hints = getMetricHints([narrowFrame]);
       expect(hints.size).toEqual(1);
       let val = [...hints][0];
       expect(val).toEqual('C-series');
     });
-    it('returns hints from CW frame', () => {
+    it('returns hints from a CW frame', () => {
       const hints = getMetricHints([frameCW]);
       expect(hints.size).toEqual(1);
       let val = [...hints][0];
       expect(val).toEqual('5XXError');
+    });
+    it('returns hints from an influxdb source', () => {
+      const hints = getMetricHints([frameInfluxDB]);
+      expect(hints.size).toEqual(1);
+      let val = [...hints][0];
+      expect(val).toEqual('changePctDay.mean { coin: btc currency: usd }');
     });
 
   });

--- a/src/components/metric_hints.ts
+++ b/src/components/metric_hints.ts
@@ -4,7 +4,8 @@ import { FieldType } from '@grafana/data';
 export const getMetricHints = (frames: any) => {
   let metricHints = new Set<string>();
   for (let i = 0; i < frames.length; i++) {
-    let hintValue;
+    // start with empty hint
+    let hintValue = '';
     // the frame may have a name defined, start with it, fields will change it as needed
     if (frames[i]?.name) {
       hintValue = frames[i].name;
@@ -12,17 +13,30 @@ export const getMetricHints = (frames: any) => {
     // iterate over fields, get all number types and provide as hints
     for (const aField of frames[i].fields) {
       if (aField.type === FieldType.number) {
-        // update the hint to use the field Name
-        if (aField.name) {
+        // update the hint to use the field Name if we didn't get a value from above
+        if ((aField.name) && (hintValue === '')) {
           hintValue = aField.name;
         }
-        // update the hint to use the displayNameFromDS value
-        if (aField?.config && aField.config?.displayNameFromDS) {
-          hintValue = aField.config?.displayNameFromDS;
-        }
-        // lastly check for a label with __name__ and use it instead
+        // check for a label with __name__ and use it instead
         if (aField?.labels && ('__name__' in aField.labels)) {
           hintValue = aField.labels['__name__'];
+          // append the rest of the labels
+          const appendLabels: string[] = [];
+          for (const aLabel in aField.labels) {
+            if (aLabel !== '__name__') {
+              appendLabels.push(`${aLabel}="${aField.labels[aLabel]}"`);
+            }
+          }
+          if (appendLabels.length > 0) {
+            // sort them first
+            appendLabels.sort();
+            hintValue += '{' + appendLabels.join('') + '}';
+          }
+        }
+        // update the hint to use the displayNameFromDS value
+        // (the query has a specified a naming convention)
+        if (aField?.config && aField.config?.displayNameFromDS) {
+          hintValue = aField.config?.displayNameFromDS;
         }
         metricHints.add(hintValue);
       }

--- a/src/data/composite_processor.test.ts
+++ b/src/data/composite_processor.test.ts
@@ -22,7 +22,7 @@ jest.mock('@grafana/runtime', () => {
           s = s.replace('$project_name', 'ProjectA');
         }
         if (s.includes('$compositeName')) {
-          s = s.replace('$compositeName', 'CompositeA');
+          s = s.replace('$compositeName', 'ProjectA');
         }
         return s;
       },
@@ -121,7 +121,6 @@ describe('Composite Processor', () => {
         return value;
       };
       const applied = ApplyComposites([compositeA], [modelA, modelB], replacer1);
-      //const applied = ApplyComposites([compositeA], [modelA, modelB], (val) => val);
       console.log(JSON.stringify(applied));
       expect(applied.length).toBe(1);
     });
@@ -144,7 +143,7 @@ describe('Composite Processor', () => {
         getTemplateSrv().replace
       );
       console.log(JSON.stringify(templatedMembers));
-      expect(templatedMembers[0].seriesName).toEqual('/API - CompositeA/');
+      expect(templatedMembers[0].seriesName).toEqual('/API - ProjectA/');
     });
   });
   describe('Custom Formatter returns expected data', () => {

--- a/src/data/composite_processor.ts
+++ b/src/data/composite_processor.ts
@@ -56,15 +56,23 @@ export const resolveMemberTemplates = (
           const templateVars: ScopedVars = {
             compositeName: { text: 'compositeName', value: compositeName },
           };
-          const resolvedSeriesName = replaceVariables(aMatch, templateVars, 'raw');
-          const newName = member.seriesMatch.replace(aMatch, resolvedSeriesName);
-          const escapedName = escapeStringForRegex(resolvedSeriesName);
-          const newNameEscaped = member.seriesMatch.replace(aMatch, escapedName);
-          ret.push({
-            ...member,
-            seriesName: newName,
-            seriesNameEscaped: newNameEscaped,
-          });
+          // template variables can be multi-select, or "all", iterate over each match
+          const resolvedSeriesNames = replaceVariables(aMatch, templateVars, customFormatter).split(CUSTOM_SPLIT_DELIMITER);
+          // iterate over the array of names
+          if (resolvedSeriesNames && resolvedSeriesNames.length) {
+            resolvedSeriesNames.forEach((aName) => {
+              if (aName.includes(compositeName)) {
+                const newName = member.seriesMatch.replace(aMatch, aName);
+                const escapedName = escapeStringForRegex(aName);
+                const newNameEscaped = member.seriesMatch.replace(aMatch, escapedName);
+                ret.push({
+                  ...member,
+                  seriesName: newName,
+                  seriesNameEscaped: newNameEscaped,
+                });
+              }
+            });
+          }
         });
       } else {
         ret.push(member);


### PR DESCRIPTION
Metric Hints for Composites (and overrides) relies on raw query results and depending on the datasource the naming may be derived from several places.

This PR enhances hints for:

- InfluxDB
   the metric name is in the "top" section of the frame, with optional labels. this adds hints that include the metric name along with the labels.  displayNameFromDS is also inspected for a formatted name in the query.

- Prometheus
    metric names were being derived exclusively from the label __name__, and did not display additional labels, this adds the additional labels so each metric can be chosen.

- CloudWatch
    metric names are derived from "displayNameFromDS"

(more to be added)

Code includes test cases to validate results, and will be expanded to cover more datasource results.
In general dataframes are consistent with names however the use of labels and newer api calls can offer alternative naming and aliasing options.

Templated Composites did not expand matched variables when there are multiple items selected (or the all option), this PR includes a fix for this scenario.
