### PR TITLE
avoid deep clone on fields

### DIFF
--- a/src/data/deframer.ts
+++ b/src/data/deframer.ts
@@ -9,8 +9,7 @@ export function InsertTime(data: DataFrame[]): DataFrame[] {
   // for now, just insert now
   const timeToInsert = Date.now();
   const newData: DataFrame[] = [];
-  for (let i = 0; i < data.length; i++) {
-    const frame = data[i];
+  for (const frame of data) {
     //const flattened = this.flattenLabels(frame, 0);
     const newFrame: DataFrame = {
       ...frame,
@@ -22,15 +21,15 @@ export function InsertTime(data: DataFrame[]): DataFrame[] {
     const hasTimestamp = frameHasTimestamp(frame);
     // rebuild a new frame with labels on the numerical fields
     const numFields = frame.fields.length;
-    for (let j = 0; j < numFields; j++) {
-      const aField = frame.fields[j];
+    for (const aField of frame.fields) {
       if (aField.type === FieldType.number) {
-        // need to get the number of rows of data for this frame
-        const rowsOfField = aField.values.toArray().length;
         if (!hasTimestamp) {
+          // need to get the number of rows of data for this frame
+          const aFieldValues = aField.values.toArray();
+          const rowsOfField = aFieldValues.length;
           for (let rowNum = 0; rowNum < rowsOfField; rowNum++) {
             // only create a new field when the rowValue is not null
-            if (aField.values.toArray()[rowNum] !== null) {
+            if (aFieldValues[rowNum] !== null) {
               // this has a non-null value
               const flattened = flattenLabels(frame, rowNum);
               const newField = newFieldWithLabels(aField, flattened);
@@ -63,8 +62,7 @@ export function InsertTime(data: DataFrame[]): DataFrame[] {
     } else {
       // time field already exists
       // copy all non-number fields from original frame
-      for (let j = 0; j < frame.fields.length; j++) {
-        const aField = frame.fields[j];
+      for (const aField of frame.fields) {
         if (aField.type !== FieldType.number) {
           newFrame.fields.push(aField);
         }

--- a/src/data/deframer.ts
+++ b/src/data/deframer.ts
@@ -12,9 +12,12 @@ export function InsertTime(data: DataFrame[]): DataFrame[] {
   for (let i = 0; i < data.length; i++) {
     const frame = data[i];
     //const flattened = this.flattenLabels(frame, 0);
-    const newFrame = lodashCloneDeep(frame);
-    // clear the fields
-    newFrame.fields = [];
+    const newFrame: DataFrame = {
+      ...frame,
+      meta: lodashCloneDeep(frame.meta),
+      fields: [], // clear the fields
+    };
+    
     //const labels = this.getLabelsOfFrame(frame);
     const hasTimestamp = frameHasTimestamp(frame);
     // rebuild a new frame with labels on the numerical fields


### PR DESCRIPTION
lodash deep clone on a frame includes a LOT of stuff, and it is all immediately thrown away so we can just avoid that here.

In core we should figure out what changed in 10x to make the speed worse -- i think the array shims may be to blame, but that can be a different issue