### PR TITLE
Allow displayLimit to be zero for unlimited polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Entries
 
+## v2.1.2
+
+- Allow display limit of 0 for unlimited polygons [#298](https://github.com/grafana/grafana-polystat-panel/issues/298)
+
 ## v2.1.1
 
 - Fixes display limit bug [#255](https://github.com/grafana/grafana-polystat-panel/issues/255)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-polystat-panel",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Grafana Polystat Panel",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/PolystatPanel.tsx
+++ b/src/components/PolystatPanel.tsx
@@ -54,7 +54,7 @@ export const PolystatPanel: React.FC<Props> = ({ options, data, id, width, heigh
   );
   const currentTheme = useTheme2();
 
-  if (processedData!.length > options.layoutDisplayLimit) {
+  if ((options.layoutDisplayLimit > 0) && (processedData!.length > options.layoutDisplayLimit)) {
     return (
       <div className={errorMessageStyles}>
         Not enough polygons for data. There are {processedData!.length} items to display,

--- a/src/components/layout/layoutManager.ts
+++ b/src/components/layout/layoutManager.ts
@@ -43,7 +43,8 @@ export class LayoutManager {
     this.maxColumnsUsed = 0;
     this.maxRowsUsed = 0;
 
-    if (displayLimit < 1 || isNaN(displayLimit)) {
+    // negative or NaN limit gets set to 100, 0 is allowed for unlimited
+    if (displayLimit < 0 || isNaN(displayLimit)) {
       this.displayLimit = 100;
     } else {
       this.displayLimit = displayLimit;

--- a/src/module.ts
+++ b/src/module.ts
@@ -91,10 +91,10 @@ export const plugin = new PanelPlugin<PolystatOptions>(PolystatPanel)
       .addNumberInput({
         path: 'layoutDisplayLimit',
         name: 'Display Limit',
-        description: 'Maximum number of polygons to display',
+        description: 'Maximum number of polygons to display (0 for unlimited)',
         defaultValue: 100,
         settings: {
-          min: 1,
+          min: 0,
           integer: true,
         },
         category: ['Layout'],


### PR DESCRIPTION
Previous patch did not account for 0 as the "unlimited" polygon setting.  The min setting is now 0, default is still 100.

If there are more polygons to render than the limit (greater than zero), an error message is displayed instead of the polygons.

Fixes #298 