### PR TITLE
Add natural sort option

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -150,6 +150,8 @@ export const SortOptions = [
   { value: 4, label: 'Numerical (desc)' },
   { value: 5, label: 'Alphabetical (case-insensitive, asc)' },
   { value: 6, label: 'Alphabetical (case-insensitive, desc)' },
+  { value: 7, label: 'Natural sort (asc)' },
+  { value: 8, label: 'Natural sort (desc)' },
 ];
 
 export const SortOptionOperators = ['disabled', 'asc', 'desc', 'asc', 'desc', 'iasc', 'idesc'];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -200,6 +200,13 @@ function SortVariableValuesByField(options: any, sortField: string, sortOrder: n
         }
       });
       break;
+    case 4: // Natural Sort
+      const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+      options = options.slice(); // Shallow clone original array
+      options.sort((a, b) => {
+        return collator.compare(a[sortField], b[sortField]);
+      });
+      break;
   }
 
   if (reverseSort) {


### PR DESCRIPTION
This commit adds support for Natural Sorting to the polystat panel plugin.

Natural Sorting is ideal for values which may contain mixed text and numbers, e.g. many host naming schemes.

For example, given the host names:

  foo-dc1-1, foo-dc1-2, foo-dc1-10, foo-dc2-1

Alphabetical sort gives:

  foo-dc1-1, foo-dc1-10, foo-dc1-2, foo-dc2-1

This sorts dc1-10 before dc1-2, which is not the order most people would expect to see the hosts in. This makes it harder for people to navigate the visualization when many hosts are present.

Numeric sort (as implemented) supports mixed text/numbers, but only supports sorting based on the first number it finds. In the above examples, that means it would sort dc1 < dc2, but would not properly sort based on the trailing number.

Natural sorting is supported in many places, and is good for sorting version numbers, host names and similar. It is already available in some places in Grafana, but is sadly not yet universally supported.

Rather than implement the sort from scratch, this implementation leans on the browser's locale-dependent API, Intl.Collator. This API is supported in all major browsers since 2016, and has the benefit that it will automatically adapt to the expectations of the user's preferred locale.