### PR TITLE
Use unique id for tooltip.

### DIFF
--- a/src/components/Polystat.tsx
+++ b/src/components/Polystat.tsx
@@ -3,7 +3,7 @@ import { textUtil } from '@grafana/data';
 import { useStyles2, Portal, useTheme2 } from '@grafana/ui';
 import { symbol as d3symbol, symbolCircle, symbolSquare } from 'd3';
 import { hexbin } from 'd3-hexbin';
-import { orderBy as lodashOrderBy, uniq } from 'lodash';
+import { orderBy as lodashOrderBy } from 'lodash';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 
 import { Gradients } from './gradients/Gradients';

--- a/src/components/Polystat.tsx
+++ b/src/components/Polystat.tsx
@@ -3,7 +3,7 @@ import { textUtil } from '@grafana/data';
 import { useStyles2, Portal, useTheme2 } from '@grafana/ui';
 import { symbol as d3symbol, symbolCircle, symbolSquare } from 'd3';
 import { hexbin } from 'd3-hexbin';
-import { orderBy as lodashOrderBy } from 'lodash';
+import { orderBy as lodashOrderBy, uniq } from 'lodash';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 
 import { Gradients } from './gradients/Gradients';
@@ -30,7 +30,7 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
   const [animatedItems, setAnimatedItems] = React.useState<number[]>([]);
   const margin = { top: 0, right: 0, bottom: 0, left: 0 };
   // this MUST be unique for gradients to work properly
-  const [gradientId] = React.useState<string>(`polystat_${options.panelId}_` + Math.floor(Math.random() * 10000).toString());
+  const [uniquePanelId] = React.useState<string>(`polystat_${options.panelId}_` + Math.floor(Math.random() * 10000).toString());
 
   const updateAnimation = (data: PolystatModel[]) => {
     if (data.length > 0) {
@@ -308,7 +308,7 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
     let fillColor = options.processedData![index].color;
     if (options.globalGradientsEnabled) {
       // TODO: safari needs the location.href
-      fillColor = `url(#${gradientId}_linear_gradient_state_data_${index})`;
+      fillColor = `url(#${uniquePanelId}_linear_gradient_state_data_${index})`;
     }
     const useRadius = lm.generateRadius(options.globalShape);
     const coords = getCoords(index);
@@ -317,11 +317,11 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
       case PolygonShapes.HEXAGON_POINTED_TOP:
         return (
           <path
-            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${options.panelId}` : null}
+            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${uniquePanelId}` : null}
             data-tooltip-content={index}
             data-tooltip-position-strategy='fixed'
             className={svgPathStyles}
-            key={`polystat-tooltip-${options.panelId}`}
+            key={`polystat-tooltip-${uniquePanelId}`}
             transform={`translate(${coords.x}, ${coords.y})`}
             d={customShape}
             fill={fillColor}
@@ -332,10 +332,10 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
       case PolygonShapes.CIRCLE:
         return (
           <circle
-            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${options.panelId}` : null}
+            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${uniquePanelId}` : null}
             data-tooltip-content={index}
             data-tooltip-position-strategy='fixed'
-            key={`polystat-tooltip-${options.panelId}`}
+            key={`polystat-tooltip-${uniquePanelId}`}
             className={svgPathStyles}
             cx={coords.x}
             cy={coords.y}
@@ -346,10 +346,10 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
       case PolygonShapes.SQUARE:
         return (
           <rect
-            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${options.panelId}` : null}
+            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${uniquePanelId}` : null}
             data-tooltip-content={index}
             data-tooltip-position-strategy='fixed'
-            key={`polystat-tooltip-${options.panelId}`}
+            key={`polystat-tooltip-${uniquePanelId}`}
             className={svgPathStyles}
             x={coords.x}
             y={coords.y}
@@ -361,11 +361,11 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
       default:
         return (
           <path
-            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${options.panelId}` : null}
+            data-tooltip-id={options.globalTooltipsEnabled ? `polystat-tooltip-${uniquePanelId}` : null}
             data-tooltip-content={index}
             data-tooltip-position-strategy='fixed'
             className={svgPathStyles}
-            key={`polystat-tooltip-${options.panelId}`}
+            key={`polystat-tooltip-${uniquePanelId}`}
             transform={`translate(${coords.x}, ${coords.y})`}
             d={customShape}
             fill={fillColor}
@@ -555,7 +555,7 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
       >
 
         <g transform={`translate(${marginLeft},${marginTop})`}>
-          <Gradients gradientId={gradientId} data={options.processedData} />
+          <Gradients gradientId={uniquePanelId} data={options.processedData} />
 
           {options.processedData!.map((item, index) => {
             const coords = getCoords(index);
@@ -594,7 +594,7 @@ export const Polystat: React.FC<PolystatOptions> = (options) => {
             style={{
               boxShadow: 'rgba(1, 4, 9, 0.75) 0px 4px 8px 0px',
             }}
-            id={options.globalTooltipsEnabled ? `polystat-tooltip-${options.panelId}` : undefined}
+            id={options.globalTooltipsEnabled ? `polystat-tooltip-${uniquePanelId}` : undefined}
             place={'bottom'} // TODO: make this configurable
             float={true}
             variant={tooltipTheme} // TODO: this could be made configurable (auto, or specified)


### PR DESCRIPTION
Replaces: #412

With scenes, the panel id is not guaranteed to be unique because panels created from a repeating panel will all get the same id. This renames the unique id for the gradient and uses that same id for the tooltip.