### PR TITLE
Feature: Apply mappings from grafana overrides tab

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,4 +1,4 @@
-import { SelectableValue } from '@grafana/data';
+import { SelectableValue, ValueMapping } from '@grafana/data';
 import { CompositeItemType } from 'components/composites/types';
 import { OverrideItemType } from './overrides/types';
 import { PolystatThreshold } from './thresholds/types';
@@ -99,6 +99,7 @@ export interface PolystatModel {
   isComposite: boolean;
   members: PolystatModel[];
   triggerCache?: any; // holds animation frame info
+  mappings?: ValueMapping[];
 }
 
 export enum PolygonShapes {

--- a/src/data/composite_processor.ts
+++ b/src/data/composite_processor.ts
@@ -128,7 +128,8 @@ const shallowClone = (item: PolystatModel): PolystatModel => {
     showValue: item.showValue,
     showTimestamp: item.showTimestamp,
     isComposite: item.isComposite,
-    members: []
+    members: [],
+    mappings: item.mappings,
   };
   return clone;
 };

--- a/src/data/override_processor.ts
+++ b/src/data/override_processor.ts
@@ -15,7 +15,7 @@ import { PolystatModel } from '../components/types';
 import { CUSTOM_SPLIT_DELIMITER } from './types';
 import { OverrideItemType } from '../components/overrides/types';
 import { PolystatThreshold } from 'components/thresholds/types';
-import { GetMappedValue } from './valueMappingsWrapper';
+import { GetMappedValue, getMappings } from './valueMappingsWrapper';
 import { roundValue } from 'utils';
 import { TimeFormatter } from './time_formatter';
 
@@ -107,7 +107,7 @@ export const ApplyOverrides = (
       data[index].thresholdLevel = result.thresholdLevel;
       // format it
       // TODO: fix me!
-      const mappings = fieldConfig.defaults.mappings && fieldConfig.defaults.mappings.length > 0 ? fieldConfig.defaults.mappings : data[index].mappings;
+      const mappings = getMappings(fieldConfig.defaults.mappings, data[index].mappings);
       const mappedValue = GetMappedValue(mappings!, data[index].value);
       if (mappedValue && mappedValue.text !== '') {
         data[index].valueFormatted = mappedValue.text;

--- a/src/data/override_processor.ts
+++ b/src/data/override_processor.ts
@@ -107,7 +107,8 @@ export const ApplyOverrides = (
       data[index].thresholdLevel = result.thresholdLevel;
       // format it
       // TODO: fix me!
-      const mappedValue = GetMappedValue(fieldConfig.defaults.mappings!, data[index].value);
+      const mappings = fieldConfig.defaults.mappings && fieldConfig.defaults.mappings.length > 0 ? fieldConfig.defaults.mappings : data[index].mappings;
+      const mappedValue = GetMappedValue(mappings!, data[index].value);
       if (mappedValue && mappedValue.text !== '') {
         data[index].valueFormatted = mappedValue.text;
         // set color also

--- a/src/data/processor.ts
+++ b/src/data/processor.ts
@@ -7,7 +7,6 @@ import {
   DataFrame,
   PanelData,
   getFieldDisplayName,
-  dateTime,
   formattedValueToString,
   getValueFormat,
   stringToJsRegex,
@@ -16,7 +15,7 @@ import {
   GrafanaTheme2,
   GrafanaTheme,
 } from '@grafana/data';
-import { includes as lodashIncludes, map } from 'lodash';
+import { includes as lodashIncludes } from 'lodash';
 import { DisplayModes, OperatorOptions, PolystatModel } from '../components/types';
 import { GLOBAL_FILL_COLOR_RGBA } from '../components/defaults';
 import { GetDecimalsForValue, SortVariableValuesByField, roundValue } from '../utils';
@@ -26,7 +25,7 @@ import { ApplyOverrides } from './override_processor';
 import { OverrideItemType } from '../components/overrides/types';
 import { PolystatThreshold } from '../components/thresholds/types';
 import { ClickThroughTransformer } from './clickThroughTransformer';
-import { GetMappedValue } from './valueMappingsWrapper';
+import { GetMappedValue, getMappings } from './valueMappingsWrapper';
 import { GetValueByOperator } from './stats';
 import { TimeFormatter } from './time_formatter';
 
@@ -227,7 +226,7 @@ export const ApplyGlobalFormatting = (
     if (data[index].value !== null) {
       data[index].showName = globalShowLabel;
       data[index].showValue = globalShowValue;
-      const mappings = fieldConfig.defaults.mappings && fieldConfig.defaults.mappings.length > 0 ? fieldConfig.defaults.mappings : data[index].mappings;
+      const mappings = getMappings(fieldConfig.defaults.mappings, data[index].mappings);
       const mappedValue = GetMappedValue(mappings!, data[index].value);
       if (mappedValue && mappedValue.text !== '') {
         data[index].valueFormatted = mappedValue.text;
@@ -380,7 +379,7 @@ export const DataFrameToPolystat = (frame: DataFrame, globalOperator: string): P
       members: [],
       customClickthroughTargetEnabled: false,
       customClickthroughTarget: '',
-      mappings: valueField.config.mappings,
+      mappings: valueField.config.mappings || [],
     };
     models.push(model);
   }

--- a/src/data/processor.ts
+++ b/src/data/processor.ts
@@ -16,7 +16,7 @@ import {
   GrafanaTheme2,
   GrafanaTheme,
 } from '@grafana/data';
-import { includes as lodashIncludes } from 'lodash';
+import { includes as lodashIncludes, map } from 'lodash';
 import { DisplayModes, OperatorOptions, PolystatModel } from '../components/types';
 import { GLOBAL_FILL_COLOR_RGBA } from '../components/defaults';
 import { GetDecimalsForValue, SortVariableValuesByField, roundValue } from '../utils';
@@ -227,7 +227,8 @@ export const ApplyGlobalFormatting = (
     if (data[index].value !== null) {
       data[index].showName = globalShowLabel;
       data[index].showValue = globalShowValue;
-      const mappedValue = GetMappedValue(fieldConfig.defaults.mappings!, data[index].value);
+      const mappings = fieldConfig.defaults.mappings && fieldConfig.defaults.mappings.length > 0 ? fieldConfig.defaults.mappings : data[index].mappings;
+      const mappedValue = GetMappedValue(mappings!, data[index].value);
       if (mappedValue && mappedValue.text !== '') {
         data[index].valueFormatted = mappedValue.text;
         if (globalShowTimestampEnabled) {
@@ -378,7 +379,8 @@ export const DataFrameToPolystat = (frame: DataFrame, globalOperator: string): P
       isComposite: false,
       members: [],
       customClickthroughTargetEnabled: false,
-      customClickthroughTarget: ''
+      customClickthroughTarget: '',
+      mappings: valueField.config.mappings,
     };
     models.push(model);
   }

--- a/src/data/valueMappingsWrapper/index.ts
+++ b/src/data/valueMappingsWrapper/index.ts
@@ -1,3 +1,4 @@
+import { ValueMapping } from '@grafana/data';
 import { getMappedValue } from './v7/valueMappings';
 import { getValueMappingResult } from './v8/valueMappings';
 
@@ -18,3 +19,7 @@ export const GetMappedValue = (valueMappings: any[], value: any): any => {
   }
   return mappedValue;
 };
+
+export const getMappings = (fieldConfigMappings: ValueMapping[] | undefined, dataMappings: ValueMapping[] | undefined) => {
+  return fieldConfigMappings && fieldConfigMappings.length > 0 ? fieldConfigMappings : dataMappings;
+}


### PR DESCRIPTION
This PRs applies mappings provided through grafana "Overrides" tab.
The overrides in the "All" tab have high priority, therefore if they are provided the ones from "Override" tab will be ignored.

Closes: https://github.com/grafana/grafana-polystat-panel/issues/272