### PR TITLE
Fix: Adjust e2e tests to cover grafana 12

### DIFF
--- a/tests/auth-bypassed/phase2-installed/check-installed.spec.ts
+++ b/tests/auth-bypassed/phase2-installed/check-installed.spec.ts
@@ -7,5 +7,5 @@ test('Check Plugin Installed', async ({ page }) => {
   await page.goto('http://localhost:3000/plugins/grafana-polystat-panel', {waitUntil: 'networkidle'});
   // get version from package.json
   const pluginVersion = packageJSON.version;
-  await expect(page.getByText(`Version${pluginVersion}`).first()).toContainText(pluginVersion);
+  await expect(page.getByText(new RegExp(`Version:?\\s*${pluginVersion}`)).first()).toContainText(pluginVersion);
 });


### PR DESCRIPTION
The text for grafana 12 version should include a colon while the previous versions didn't need any.