### PR TITLE
chore: transfer codeowners to dataviz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
-* @grafana/plugins-platform-frontend
+* @grafana/dataviz-squad


### PR DESCRIPTION
Reorg changes mean this plugin is no longer owned by plugins platform.