### PR TITLE
security: disable postinstall/lifecycle scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,4 @@ enableTelemetry: 0
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+enableScripts: false


### PR DESCRIPTION
## Why
Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during
`npm install` / `yarn install` and are a common supply-chain attack vector.

## What changed
- `.npmrc` → `ignore-scripts=true`
- `.yarnrc` → `ignore-scripts true`  *(Yarn Classic repos only)*
- `.yarnrc.yml` → `enableScripts: false`  *(Yarn Berry repos only)*

## References
- [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)
- [Yarn Berry docs](https://yarnpkg.com/configuration/yarnrc#enableScripts)

> Opened automatically by `bulk_disable_scripts.py` — ping #security with questions.
